### PR TITLE
update-search-endpoint-to-reduce-response-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@
 
 #### Search Games
 
+* Search
+  * by default the response only returns name, bgg_id, year_published and image_url
+  * to display the full response add `extended=true` to the query params
 * Search - partial match
   * Request
     * GET `/games?name=stop`

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -53,4 +53,8 @@ class Game < ApplicationRecord
   def expansion?
     base_game_id.present?
   end
+
+  def image_url
+    Rails.application.routes.url_helpers.url_for(image) if image.attached?
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,3 +70,5 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = false
 end
+
+Rails.application.routes.default_url_options[:host] = "http://localhost:3000"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,3 +96,5 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end
+
+Rails.application.routes.default_url_options[:host] = "https://board-games-api.boardgametools.net"


### PR DESCRIPTION
Changes search endpoint default response to be smaller and use a query parameter to show the extended response.